### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/CivirulesLog.php
+++ b/api/v3/CivirulesLog.php
@@ -9,7 +9,7 @@ use CRM_Civiruleslogger_ExtensionUtil as E;
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civirules_log_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'CivirulesLog');
@@ -23,7 +23,7 @@ function civicrm_api3_civirules_log_create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civirules_log_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -37,7 +37,7 @@ function civicrm_api3_civirules_log_delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civirules_log_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'CivirulesLog');

--- a/api/v3/CivirulesLogger/Prunelog.php
+++ b/api/v3/CivirulesLogger/Prunelog.php
@@ -7,7 +7,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_civirules_logger_prunelog($params) {
   CRM_Core_DAO::executeQuery("DELETE FROM `civirule_civiruleslogger_log` WHERE `timestamp` < (CURDATE() - INTERVAL 3 MONTH)");


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.